### PR TITLE
Use <pre> to format raw message HTML in info window, make it a bit wider as well

### DIFF
--- a/Resources/public/pimcore/js/list.js
+++ b/Resources/public/pimcore/js/list.js
@@ -230,14 +230,14 @@ coreshop.messenger.list = Class.create({
                         var record = grid.getStore().getAt(rowIndex);
 
                         new Ext.Window({
-                            width: 500,
+                            width: 600,
                             height: 550,
                             title: t('info'),
                             modal: true,
                             layout: "fit",
                             items: [{
                                 padding: 10,
-                                html: record.data.serialized
+                                html: '<pre>' + record.data.serialized + '</pre>'
                             }]
                         }).show();
                     }
@@ -378,14 +378,14 @@ coreshop.messenger.list = Class.create({
                         var record = grid.getStore().getAt(rowIndex);
 
                         new Ext.Window({
-                            width: 500,
+                            width: 600,
                             height: 550,
                             title: t('info'),
                             modal: true,
                             layout: "fit",
                             items: [{
                                 padding: 10,
-                                html: record.data.serialized
+                                html: '<pre>' + record.data.serialized + '</pre>'
                             }]
                         }).show();
                     }


### PR DESCRIPTION
Result:
![Screenshot 2023-12-07 at 15 45 51](https://github.com/coreshop/MessengerBundle/assets/279826/4b40e573-8af4-43ef-bd99-bdd1f40bd1e3)
